### PR TITLE
Add support for Python 3.9

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,4 +22,4 @@ pyaudio = "*"
 bandit = "*"
 
 [requires]
-python_version = "3.10"
+python_version = "3.9.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.9.13"
         },
         "sources": [
             {

--- a/hf_rvc/models/feature_extraction_rvc.py
+++ b/hf_rvc/models/feature_extraction_rvc.py
@@ -134,9 +134,9 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
     def __call__(
         self,
         audio: np.ndarray,
-        sampling_rate: Any = None,
+        sampling_rate: int or None = None,
         f0_up_key: float = 0,
-        return_tensors: Any = None,
+        return_tensors: str or TensorType or None = None,
     ) -> BatchFeature:
         input_values = Wav2Vec2FeatureExtractor.__call__(
             self, audio, sampling_rate=sampling_rate
@@ -171,7 +171,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
         self._f0_extractor = F0_EXTRACTORS.get(f0_method)
 
     def _extract_f0_features(
-        self, audio: np.ndarray, f0_up_key: float = 0, p_len: Any = None
+        self, audio: np.ndarray, f0_up_key: float = 0, p_len: int or None = None
     ) -> tuple[np.ndarray, np.ndarray]:
         if p_len is None:
             p_len = audio.shape[-1] // self.window

--- a/hf_rvc/models/feature_extraction_rvc.py
+++ b/hf_rvc/models/feature_extraction_rvc.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 import numpy as np
 from transformers import Wav2Vec2FeatureExtractor
@@ -134,9 +134,9 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
     def __call__(
         self,
         audio: np.ndarray,
-        sampling_rate: int or None = None,
+        sampling_rate: Union[int, None] = None,
         f0_up_key: float = 0,
-        return_tensors: str or TensorType or None = None,
+        return_tensors: Union[str, TensorType, None] = None,
     ) -> BatchFeature:
         input_values = Wav2Vec2FeatureExtractor.__call__(
             self, audio, sampling_rate=sampling_rate
@@ -171,7 +171,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
         self._f0_extractor = F0_EXTRACTORS.get(f0_method)
 
     def _extract_f0_features(
-        self, audio: np.ndarray, f0_up_key: float = 0, p_len: int or None = None
+        self, audio: np.ndarray, f0_up_key: float = 0, p_len: Union[int, None] = None
     ) -> tuple[np.ndarray, np.ndarray]:
         if p_len is None:
             p_len = audio.shape[-1] // self.window

--- a/hf_rvc/models/feature_extraction_rvc.py
+++ b/hf_rvc/models/feature_extraction_rvc.py
@@ -134,9 +134,9 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
     def __call__(
         self,
         audio: np.ndarray,
-        sampling_rate: int | None = None,
+        sampling_rate: Any = None,
         f0_up_key: float = 0,
-        return_tensors: str | TensorType | None = None,
+        return_tensors: Any = None,
     ) -> BatchFeature:
         input_values = Wav2Vec2FeatureExtractor.__call__(
             self, audio, sampling_rate=sampling_rate
@@ -171,7 +171,7 @@ class RVCFeatureExtractor(Wav2Vec2FeatureExtractor):
         self._f0_extractor = F0_EXTRACTORS.get(f0_method)
 
     def _extract_f0_features(
-        self, audio: np.ndarray, f0_up_key: float = 0, p_len: int | None = None
+        self, audio: np.ndarray, f0_up_key: float = 0, p_len: Any = None
     ) -> tuple[np.ndarray, np.ndarray]:
         if p_len is None:
             p_len = audio.shape[-1] // self.window

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.9.13
 
 [options]
 packages=find:
@@ -24,7 +24,7 @@ install_requires =
     argh
     safetensors
     librosa
-python_requires = >=3.10
+python_requires = >=3.9.13
 
 [options.extras_require]
 converter = fairseq


### PR DESCRIPTION
Replaced `|` type operator with `Union` for compatibility with Python 3.9